### PR TITLE
Issue: Change toasts to AlertDialogBox

### DIFF
--- a/app/src/main/java/com/example/hris/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/hris/ui/LoginActivity.kt
@@ -42,7 +42,7 @@ class LoginActivity : AppCompatActivity() {
             val username = binding.txtUserID.text.toString()
             val password = binding.txtPassword.text.toString()
 
-            viewModel.userLogin(username, password, this)
+            viewModel.userLogin(username, password)
         }
 
         viewModel.liveDataSuccess.observe(this) {

--- a/app/src/main/java/com/example/hris/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/hris/ui/LoginActivity.kt
@@ -1,10 +1,10 @@
 package com.example.hris.ui
 
+import android.app.AlertDialog
 import android.app.Dialog
 import android.content.Intent
 import android.os.Bundle
 import android.view.Window
-import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.example.hris.R
@@ -25,6 +25,14 @@ class LoginActivity : AppCompatActivity() {
         }
     }
 
+    private val builder: AlertDialog.Builder by lazy {
+        AlertDialog.Builder(this).apply {
+            this.setPositiveButton(R.string.ok) { dialog, _ ->
+                dialog.dismiss()
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityLoginBinding.inflate(layoutInflater)
@@ -34,7 +42,7 @@ class LoginActivity : AppCompatActivity() {
             val username = binding.txtUserID.text.toString()
             val password = binding.txtPassword.text.toString()
 
-            viewModel.userLogin(username, password)
+            viewModel.userLogin(username, password, this)
         }
 
         viewModel.liveDataSuccess.observe(this) {
@@ -47,7 +55,7 @@ class LoginActivity : AppCompatActivity() {
         }
 
         viewModel.message.observe(this) {
-            Toast.makeText(this, it, Toast.LENGTH_SHORT).show()
+            setErrorDialog(it)
         }
     }
 
@@ -57,5 +65,10 @@ class LoginActivity : AppCompatActivity() {
         } else {
             loadingDialog.dismiss()
         }
+    }
+
+    private fun setErrorDialog(message: String) {
+        builder.setMessage(message)
+        builder.show()
     }
 }

--- a/app/src/main/java/com/example/hris/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/hris/ui/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.hris.ui
 
+import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
 import android.view.Window
@@ -25,6 +26,14 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private val builder: AlertDialog.Builder by lazy {
+        AlertDialog.Builder(this).apply {
+            this.setPositiveButton(R.string.ok) { dialog, _ ->
+                dialog.dismiss()
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val binding = ActivityMainBinding.inflate(layoutInflater)
@@ -47,8 +56,8 @@ class MainActivity : AppCompatActivity() {
             true
         }
 
-        navController.addOnDestinationChangedListener{_, destination, _ ->
-            when(destination.id) {
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            when (destination.id) {
                 R.id.profileFragment -> navBar.menu.getItem(2).isChecked = true
                 R.id.leavesFragment -> navBar.menu.getItem(1).isChecked = true
                 R.id.timeLogsFragment -> navBar.menu.getItem(0).isChecked = true
@@ -58,13 +67,22 @@ class MainActivity : AppCompatActivity() {
         viewModel.apiBool.observe(this) {
             setLoadingDialog(it)
         }
+
+        viewModel.errorMessage.observe(this) {
+            setErrorDialog(it)
+        }
     }
 
-    private fun setLoadingDialog(loading: Boolean) {
-        if (loading) {
+    private fun setLoadingDialog(isLoading: Boolean) {
+        if (isLoading) {
             loadingDialog.show()
         } else {
             loadingDialog.dismiss()
         }
+    }
+
+    private fun setErrorDialog(message: String) {
+        builder.setMessage(message)
+        builder.show()
     }
 }

--- a/app/src/main/java/com/example/hris/ui/fragments/leaves/FileLeaveFragment.kt
+++ b/app/src/main/java/com/example/hris/ui/fragments/leaves/FileLeaveFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.AdapterView.OnItemSelectedListener
-import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -80,7 +79,7 @@ class FileLeaveFragment : Fragment() {
         }
 
         viewModel.message.observe(viewLifecycleOwner) {
-            Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+            mainViewModel.errorMessage.value = it
         }
 
         viewModel.loadingDialogState.observe(viewLifecycleOwner) {
@@ -88,7 +87,6 @@ class FileLeaveFragment : Fragment() {
         }
 
         viewModel.isSuccess.observe(viewLifecycleOwner) {
-            Toast.makeText(requireContext(), "Leave successfully filed", Toast.LENGTH_SHORT).show()
             val action =
                 FileLeaveFragmentDirections.actionFileLeaveFragmentToFileLeaveSuccessFragment(
                     Leaves(

--- a/app/src/main/java/com/example/hris/ui/fragments/leaves/LeavesFragment.kt
+++ b/app/src/main/java/com/example/hris/ui/fragments/leaves/LeavesFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -47,7 +46,7 @@ class LeavesFragment : Fragment() {
         }
 
         viewModel.message.observe(viewLifecycleOwner) {
-            Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+            mainViewModel.errorMessage.value = it
         }
 
         viewModel.leaves.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/example/hris/ui/fragments/profile/UpdateProfileFragment.kt
+++ b/app/src/main/java/com/example/hris/ui/fragments/profile/UpdateProfileFragment.kt
@@ -4,8 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.example.hris.convertToLocalPhone
@@ -22,7 +22,7 @@ class UpdateProfileFragment : Fragment() {
 
     private lateinit var binding: FragmentUpdateProfileBinding
     private val viewModel: UpdateProfileViewModel by viewModels()
-    private val mainViewModel: MainActivityViewModel by viewModels()
+    private val mainViewModel: MainActivityViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -69,7 +69,7 @@ class UpdateProfileFragment : Fragment() {
         }
 
         viewModel.message.observe(viewLifecycleOwner) {
-            Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+            mainViewModel.errorMessage.value = it
         }
 
         viewModel.isSuccessful.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/example/hris/ui/fragments/profile/UpdateProfileFragment.kt
+++ b/app/src/main/java/com/example/hris/ui/fragments/profile/UpdateProfileFragment.kt
@@ -43,7 +43,6 @@ class UpdateProfileFragment : Fragment() {
                 emailAddress = binding.txtEmail.text.toString(),
                 mobileNumber = binding.txtMobileNumber.text.toString().convertToLocalPhone(),
                 landline = binding.txtLandLine.text.toString().convertToLocalLandline(),
-                context = requireContext()
             )
         }
 

--- a/app/src/main/java/com/example/hris/ui/fragments/timelogs/AddTimeLogFragment.kt
+++ b/app/src/main/java/com/example/hris/ui/fragments/timelogs/AddTimeLogFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -49,11 +48,10 @@ class AddTimeLogFragment : Fragment() {
         }
 
         viewModel.message.observe(viewLifecycleOwner) {
-            Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+            mainViewModel.errorMessage.value = it
         }
 
         viewModel.liveDataSuccess.observe(viewLifecycleOwner) {
-            Toast.makeText(requireContext(), "Time log successfully added", Toast.LENGTH_SHORT).show()
             val action =
                 AddTimeLogFragmentDirections.actionAddTimeLogsFragmentToAddTimeLogSuccessFragment(
                     binding.Spinner.selectedItem.toString()

--- a/app/src/main/java/com/example/hris/ui/fragments/timelogs/TimeLogsFragment.kt
+++ b/app/src/main/java/com/example/hris/ui/fragments/timelogs/TimeLogsFragment.kt
@@ -4,12 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.example.hris.R
 import com.example.hris.databinding.FragmentTimeLogsBinding
 import com.example.hris.ui.adapters.TimeLogsListAdapter
 import com.example.hris.ui.viewmodels.MainActivityViewModel
@@ -46,7 +44,7 @@ class TimeLogsFragment : Fragment() {
         }
 
         viewModel.message.observe(viewLifecycleOwner) {
-            Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+            mainViewModel.errorMessage.value = it
         }
 
         viewModel.timeLogs.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/example/hris/ui/viewmodels/LoginViewModel.kt
+++ b/app/src/main/java/com/example/hris/ui/viewmodels/LoginViewModel.kt
@@ -23,7 +23,7 @@ class LoginViewModel @Inject constructor(
     val loadingDialogState = MutableLiveData<Boolean>()
     val message = MutableLiveData<String>()
 
-    fun userLogin(username: String, password: String, context: Context) {
+    fun userLogin(username: String, password: String) {
         viewModelScope.launch {
             loadingDialogState.value = true
             try {
@@ -36,7 +36,7 @@ class LoginViewModel @Inject constructor(
                     message.value = loginResponse.message!!
                 }
             } catch (networkError: IOException) {
-                message.value = context.getString(R.string.network_error)
+                message.value = getApplication<Application>().getString(R.string.network_error)
                 loadingDialogState.value = false
             }
             catch (networkError: TimeoutException){

--- a/app/src/main/java/com/example/hris/ui/viewmodels/LoginViewModel.kt
+++ b/app/src/main/java/com/example/hris/ui/viewmodels/LoginViewModel.kt
@@ -1,12 +1,16 @@
 package com.example.hris.ui.viewmodels
 
 import android.app.Application
+import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
+import com.example.hris.R
 import com.example.hris.repository.HrisRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import java.io.IOException
+import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,16 +23,24 @@ class LoginViewModel @Inject constructor(
     val loadingDialogState = MutableLiveData<Boolean>()
     val message = MutableLiveData<String>()
 
-    fun userLogin(username: String, password: String) {
+    fun userLogin(username: String, password: String, context: Context) {
         viewModelScope.launch {
             loadingDialogState.value = true
-            val loginResponse = hrisRepository.login(username = username, password = password)
-            loadingDialogState.value = false
+            try {
+                val loginResponse = hrisRepository.login(username = username, password = password)
+                loadingDialogState.value = false
 
-            if (loginResponse.isSuccess) {
-                liveDataSuccess.value = Unit
-            } else {
-                message.value = loginResponse.message!!
+                if (loginResponse.isSuccess) {
+                    liveDataSuccess.value = Unit
+                } else {
+                    message.value = loginResponse.message!!
+                }
+            } catch (networkError: IOException) {
+                message.value = context.getString(R.string.network_error)
+                loadingDialogState.value = false
+            }
+            catch (networkError: TimeoutException){
+                loadingDialogState.value = false
             }
         }
     }

--- a/app/src/main/java/com/example/hris/ui/viewmodels/MainActivityViewModel.kt
+++ b/app/src/main/java/com/example/hris/ui/viewmodels/MainActivityViewModel.kt
@@ -12,5 +12,6 @@ class MainActivityViewModel @Inject constructor(
 ) : AndroidViewModel(application) {
 
     val apiBool = MutableLiveData<Boolean>()
+    val errorMessage = MutableLiveData<String>()
 
 }

--- a/app/src/main/java/com/example/hris/ui/viewmodels/profile/UpdateProfileViewModel.kt
+++ b/app/src/main/java/com/example/hris/ui/viewmodels/profile/UpdateProfileViewModel.kt
@@ -1,7 +1,6 @@
 package com.example.hris.ui.viewmodels.profile
 
 import android.app.Application
-import android.content.Context
 import android.util.Patterns
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
@@ -30,7 +29,6 @@ class UpdateProfileViewModel @Inject constructor(
         emailAddress: String,
         mobileNumber: String,
         landline: String?,
-        context: Context
     ) {
         if (areInputsValid(
                 firstName = firstName,
@@ -39,7 +37,6 @@ class UpdateProfileViewModel @Inject constructor(
                 emailAddress = emailAddress,
                 mobileNumber = mobileNumber,
                 landline = landline,
-                context = context
             )
         ) {
             viewModelScope.launch {
@@ -70,20 +67,19 @@ class UpdateProfileViewModel @Inject constructor(
         emailAddress: String,
         mobileNumber: String,
         landline: String?,
-        context: Context
     ): Boolean {
         if (!Regex("^([A-Za-z\\s]+$)").matches(firstName)) {
-            message.value = context.getString(R.string.first_name_error)
-        } else if (!middleName.isNullOrEmpty() && !Regex("^([A-Za-z\\s]+$)").matches(middleName!!)) {
-            message.value = context.getString(R.string.middle_name_error)
+            message.value = getApplication<Application>().getString(R.string.first_name_error)
+        } else if (!middleName.isNullOrEmpty() && !Regex("^([A-Za-z\\s]+$)").matches(middleName)) {
+            message.value = getApplication<Application>().getString(R.string.middle_name_error)
         } else if (!Regex("^([A-Za-z\\s]+$)").matches(lastName)) {
-            message.value = context.getString(R.string.last_name_error)
+            message.value = getApplication<Application>().getString(R.string.last_name_error)
         } else if (!Patterns.EMAIL_ADDRESS.matcher(emailAddress).matches()) {
-            message.value = context.getString(R.string.email_address_error)
+            message.value = getApplication<Application>().getString(R.string.email_address_error)
         } else if (!Regex("^(09[0-9]{9}$)").matches(mobileNumber)) {
-            message.value = context.getString(R.string.mobile_number_error)
-        } else if (!landline.isNullOrEmpty() && !Regex("^(0[0-9]{9}$)").matches(landline!!)) {
-            message.value = context.getString(R.string.landline_number_error)
+            message.value = getApplication<Application>().getString(R.string.mobile_number_error)
+        } else if (!landline.isNullOrEmpty() && !Regex("^(0[0-9]{9}$)").matches(landline)) {
+            message.value = getApplication<Application>().getString(R.string.landline_number_error)
         } else {
             return true
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="in">IN</string>
     <string name="out">OUT</string>
     <string name="type">Type</string>
-    <string name="you_have_successfully_save_the_following_details">You have successfully save the following details:</string>
+    <string name="you_have_successfully_save_the_following_details">You have successfully saved the following details:</string>
     <string name="time">Time</string>
     <string name="time_in">Time In</string>
     <string name="ok">OK</string>
@@ -62,12 +62,16 @@
     <string name="vacation_leave">Vacation Leave</string>
 
     <!--  update profile error messages  -->
-    <string name="first_name_error"> First name can not be empty or contain special characters and/or numbers </string>
-    <string name="last_name_error"> Last name can not be empty or contain special characters and/or numbers </string>
-    <string name="middle_name_error"> Middle name can not contain special characters and/or numbers </string>
-    <string name="mobile_number_error"> Invalid mobile phone number </string>
-    <string name="email_address_error"> Invalid email address format </string>
-    <string name="landline_number_error"> Invalid landline number (2 digit Area code + 8 + 7 digit number) </string>
+    <string name="first_name_error"> First name can not be empty or contain special characters and/or numbers. </string>
+    <string name="last_name_error"> Last name can not be empty or contain special characters and/or numbers. </string>
+    <string name="middle_name_error"> Middle name can not contain special characters and/or numbers. </string>
+    <string name="mobile_number_error"> Invalid mobile phone number. </string>
+    <string name="email_address_error"> Invalid email address. </string>
+    <string name="landline_number_error"> Invalid landline number, please use this format
+        \n (2 digit Area code + 8 + 7 digit number) </string>
 
-
+    <!--  API Errors  -->
+    <string name="network_error"> Error connecting to the server, please check your internet connection
+        or try again later.</string>
+    <string name="timeout_error"> Connection timed out, please check your internet connection or try again later.</string>
 </resources>


### PR DESCRIPTION
## What's in this PR

- Closes #6 

- Changed all error messages that used toasts into an alertDialogBox reference in their parent activity for reusability and better user experience

## How Has This Been Tested?

Checked all fragments that previously had toasts messages and tried to create catchable error scenarios:
- In `updateProfileFragment` changed text that doesn't match the Regex to ensure that all errors have converted to using AlertDialogBox.
- In `loginActivity`, tried to sign in using an invalid account.

## Screenshots

table:
| Before | After |
| -- | -- |
| <img src="https://user-images.githubusercontent.com/111413100/214458518-7c4250c8-ecbc-4c98-8ee7-94b6059adcc2.png" height="800"> | <img src="https://user-images.githubusercontent.com/111413100/214458771-b2831554-e191-4ce0-9818-576e7a253991.png" height="800"> |